### PR TITLE
Update building script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# prepare directory
+mkdir dist
+
 # normal release
 cat \
 	src/adapter-normal/_intro.js \


### PR DESCRIPTION
- 在合并文件之前准备好 `/dist/` 目录：由于暂时把此目录排除出去了（参 5a2e556863eb8b4383323c158ec91cb681b7922f ），每次 build 前需要确保它是存在的。
