### PR TITLE
Update `ua` module.

### DIFF
--- a/src/ua.js
+++ b/src/ua.js
@@ -10,7 +10,10 @@ void function (window, _ext) {
 	var style = document.documentElement.style
 	ua.isWebKit = 'webkitTransform' in style
 	ua.isMoz = 'MozTransform' in style
-	ua.isTouchDevice = 'TouchEvent' in window
+	//we want it to work with chrome's touch device simulator,
+	//so we don't use `document.createTouch` to detect.
+	ua.isTouchDevice = ('ontouchstart' in window) && ('ontouchmove' in window) &&
+			('ontouchend' in window)
 
 	//detect by ua string
 	var str = ua.str = navigator.userAgent

--- a/test/test-ua.js
+++ b/test/test-ua.js
@@ -13,9 +13,13 @@ describe('UA', function () {
 		})
 		describe('_.ua.isTouchDevice', function () {
 			it('mean element has `touch-` event', function () {
-				expect(!!_.ua.isTouchDevice).to.equal('ontouchstart' in window)
-				expect(!!_.ua.isTouchDevice).to.equal('ontouchmove' in window)
-				expect(!!_.ua.isTouchDevice).to.equal('ontouchend' in window)
+				//this test case is based on the idea of feature detection.
+				if (_.ua.isTouchDevice) {
+					expect('TouchEvent' in window).to.be.true
+					expect('ontouchstart' in window).to.be.true
+					expect('ontouchmove' in window).to.be.true
+					expect('ontouchend' in window).to.be.true
+				}
 			})
 		})
 	})


### PR DESCRIPTION
调整了 `isTouchDevice` 的探测方式，令其在兼容 Chrome 的触摸模拟模式的同时，排除掉 Chrome 的常规模式。

Chrome 在常规模式下也有 `window.TouchEvent`。暂时不深究，先解决问题。

---

在测试代码中，为了绕开桌面浏览器对触摸特性的不确定的支持情况，把测试用例以“特性检测”的思路进行改写：当 `isTouchDevice` 时，如果探测到某些触摸特性即认为测试用例通过；不去管相反的情况。
