### PR TITLE
Remove unnecessary config of `template` module.

### DIFF
--- a/dist/underscore.ext.js
+++ b/dist/underscore.ext.js
@@ -4,13 +4,16 @@
 void function (window, undefined) {
 	'use strict'
 
+
 ////////////////////  var  ////////////////////
 var _ = window._
 var $ = window.Zepto || window.jQuery || window.$
 var document = window.document
 
+
 //check dependency
 if (!_ || !$) return false
+
 
 ////////////////////  core  ////////////////////
 //namespace
@@ -59,6 +62,7 @@ void function (window, _ext) {
 	}
 
 }(window, _ext)
+
 
 ////////////////////  str - backup for underscore.string  ////////////////////
 //this file contains apis same as underscore.string's.
@@ -142,6 +146,7 @@ void function (window, _ext) {
 	//exports
 	_ext.exports('str', str)
 }(window, _ext)
+
 
 ////////////////////  str  ////////////////////
 void function (window, _ext) {
@@ -240,6 +245,7 @@ void function (window, _ext) {
 	_ext.exports('str', str)
 }(window, _ext)
 
+
 ////////////////////  root  ////////////////////
 void function (window, _ext) {
 	'use strict'
@@ -261,6 +267,7 @@ void function (window, _ext) {
 
 	_ext.exports('root', root)
 }(window, _ext)
+
 
 ////////////////////  ua  ////////////////////
 void function (window, _ext) {
@@ -338,15 +345,13 @@ void function (window, _ext) {
 	_ext.exports('ua', ua)
 }(window, _ext)
 
+
 ////////////////////  url  ////////////////////
 void function (window, _ext) {
 	'use strict'
 
 	//namespace
 	var url = {}
-
-	//page type
-	url.isInFrame = window.self !== window.top
 
 	//basic info
 	var loc = window.location
@@ -550,6 +555,7 @@ void function (window, _ext) {
 	_ext.exports('url', url)
 }(window, _ext)
 
+
 ////////////////////  dom  ////////////////////
 void function (window, _ext) {
 	'use strict'
@@ -609,11 +615,13 @@ void function (window, _ext) {
 	_ext.exports('dom', dom)
 }(window, _ext)
 
+
 ////////////////////  action  ////////////////////
 //include and wrap external module: action.js
 
 void function (window, _ext) {
 	'use strict'
+
 
 /**
  * Action - Easy and lazy solution for click-event-binding.
@@ -725,15 +733,18 @@ var action = function () {
 
 }()
 
+
 	//exports
 	_ext.exports('action', action)
 }(window, _ext)
+
 
 ////////////////////  template  ////////////////////
 //include and wrap external module: underscore-template
 
 void function (window, _ext) {
 	'use strict'
+
 
 /**
  * Underscore-template - More APIs for Underscore's template engine - template fetching, rendering and caching.
@@ -889,19 +900,10 @@ var template = function () {
 
 }()
 
-var _config = {
-	//compatible with ejs
-	interpolate : /<%-([\s\S]+?)%>/g,
-	escape      : /<%=([\s\S]+?)%>/g,
-
-	//to avoid use `with` in compiled templates
-	//see: https://github.com/cssmagic/blog/issues/4
-	variable: 'data'
-}
-_.extend(_.templateSettings, _config)
 
 	//exports
 	_ext.exports('template', template)
 }(window, _ext)
+
 
 }(this);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var scripts = [
 	'./src/adapter-dist-trad/_intro.js',
 	'./src/adapter-dist-trad/var.js',
 	'./src/adapter-dist-trad/_defense.js',
+
 	'./src/core.js',
 	'./src/str-backup.js',
 	'./src/str.js',
@@ -16,13 +17,15 @@ var scripts = [
 	'./src/ua.js',
 	'./src/url.js',
 	'./src/dom.js',
+
 	'./src/adapter-mod-action/_intro.js',
 	'./bower_components/action/src/action.js',
 	'./src/adapter-mod-action/_outro.js',
+
 	'./src/adapter-mod-template/_intro.js',
 	'./bower_components/underscore-template/src/underscore-template.js',
-	'./src/adapter-mod-template/config.js',
 	'./src/adapter-mod-template/_outro.js',
+
 	'./src/adapter-dist-trad/_outro.js'
 ]
 

--- a/src/adapter-mod-template/config.js
+++ b/src/adapter-mod-template/config.js
@@ -1,7 +1,0 @@
-
-var _config = {
-	//compatible with ejs
-	interpolate : /<%-([\s\S]+?)%>/g,
-	escape      : /<%=([\s\S]+?)%>/g
-}
-_.extend(_.templateSettings, _config)

--- a/test/test-dev.html
+++ b/test/test-dev.html
@@ -35,7 +35,6 @@ var expect = chai.expect
 <script src="../bower_components/action/src/action.js"></script>
 <script>_.action = action</script>
 <script src="../bower_components/underscore-template/src/underscore-template.js"></script>
-<script src="../src/adapter-mod-template/config.js"></script>
 <script>_.extend(_.template, template)</script>
 <!-- test-case -->
 <script src="test-str-backup.js"></script>

--- a/test/test-template.js
+++ b/test/test-template.js
@@ -1,4 +1,13 @@
 describe('Template', function () {
+	before(function () {
+		var _config = {
+			variable: 'data',
+			interpolate: /<%-([\s\S]+?)%>/g,
+			escape:      /<%=([\s\S]+?)%>/g,
+		}
+		_.extend(_.templateSettings, _config)
+	})
+
 	describe('APIs', function () {
 		//const
 		var TEMPLATE_ELEM_ID_1 = 'elem-paragraph'


### PR DESCRIPTION
去除对 `template` 所作的任何配置，默认使用 underscore 的原始配置。这样高级使用者可以自行决定如保配置，同时也不会让初级使用者感到困扰。

相关：#47
